### PR TITLE
CMake: bump to >= 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # General parameters
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 project(qpmad VERSION 1.4.0)
 
 # --------------


### PR DESCRIPTION
Hi,

CMake 4, released more than a year ago, and available in Ubuntu 26.04 / ROS lyrical, [has dropped compatibility with versions older than 3.5](https://cmake.org/cmake/help/v4.0/release/4.0.html#deprecated-and-removed-features):

```cmake
  Starting >>> qpmad
  --- stderr: qpmad
  CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

  ---
  Failed   <<< qpmad [0.05s, exited with code 1]

```

This patch bumps the minimal required version of CMake to 3.10.

I've set it to 3.10, so it doesn’t get deprecated as soon as 3.5 will be, and yet doesn’t impose a too new CMake release to build. For reference, the oldest maintained LTS debian already has CMake 3.18.